### PR TITLE
Responders dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,3 @@ gem 'kaminari'
 gem "ransack"
 gem "squeel"
 gem 'sqlite3'
-gem 'responders', '~> 2.0'

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,3 +1,5 @@
+require "responders"
+
 require "resources/actions"
 require "resources/rest_actions"
 require "resources/configuration"

--- a/resources.gemspec
+++ b/resources.gemspec
@@ -21,10 +21,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency             "rails", '>= 3', '>= 3.2'
+  s.add_dependency "rails", '>= 3', '>= 3.2'
+  s.add_dependency "responders", '~> 2.0'
+
   s.add_development_dependency "factory_girl", '>= 3'
   s.add_development_dependency "database_cleaner", '~> 1.4', '>= 1.4.1'
   s.add_development_dependency "faker", '~> 1.4', '>= 1.4.3'
   s.add_development_dependency "rspec", '~> 3.2', '>= 3.2.0'
-
 end


### PR DESCRIPTION
Responders should be a dependency if it is being used. Don't rely on the application to add a dependency that is required by the gem.

Without adding this gem as a dependency and without it being part of your application, you will get an error saying

```
The controller-level `respond_to' feature has been extracted to the `responders` gem. Add it to your Gemfile to continue using this feature: gem 'responders', '~> 2.0' Consult the Rails upgrade guide for details.
```
